### PR TITLE
Fix docker build by switching Temurin JRE image to alpine version

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:21-jre-alpine
 
 RUN addgroup --system javauser && adduser --system --shell /bin/false --ingroup javauser javauser
 COPY --chown=javauser:javauser target/app.jar app.jar


### PR DESCRIPTION
This PR fixes the Docker build issue as the user and group add commands are different on Ubuntu (apparently the default distro). Explicitly referring to the Alpine distro does the job.